### PR TITLE
Add filemorph.json domain configuration

### DIFF
--- a/domains/filemorph.json
+++ b/domains/filemorph.json
@@ -1,6 +1,7 @@
 {
   "owner": {
-    "email": "ianagamot@gmail.com"
+    "email": "ianagamot@gmail.com",
+    "name": "Ian Gamott"
   },
   "record": {
     "CNAME": "gamott.github.io"


### PR DESCRIPTION
Solicito el subdominio filemorph.is-a.dev

✔️ El archivo está en la carpeta `domains/` y es `.json`  
✔️ El nombre del archivo es válido  
✔️ El sitio web funciona: https://gamott.github.io/filemorph  
✔️ He proporcionado un correo válido

Gracias.
